### PR TITLE
v0.1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ uwuipy/__pycache__
 uwuipy.egg-info/
 dist/
 build/
-uwuipy.egg-info/
 .idea
+poetry.lock
+.vscode
+__pycache__

--- a/README.md
+++ b/README.md
@@ -28,40 +28,42 @@ print(uwu.uwuify(input()))
 ```
 
 #### Constructor parameters
-The `uwuipy` constructor allows fine-tuning of the uwuification process through the following parameters:
+The `Uwuipy` constructor allows fine-tuning of the uwuification process through the following parameters:
 
 - `seed`: An integer seed for the random number generator. Defaults to current time if - not provided.
 - `stutterchance`: Probability of stuttering a word (0 to 1.0), default 0.1.
 - `facechance`: Probability of adding a face (0 to 1.0), default 0.05.
 - `actionchance`: Probability of adding an action (0 to 1.0), default 0.075.
 - `exclamationchance`: Probability of adding exclamations (0 to 1.0), default 1.
-- `nsfw_actions`: Enables more explicit actions if set to true; default is false.
+- `nsfw_actions`: Enables more "explicit" actions if set to true; default is false.
+- `power`: The uwuification "level" — higher levels lead to more text transformations being done (1 is core uwu, 2 is nyaification, 3 and 4 are just extra). Using a higher level includes the lower levels.
 
 #### Customized Example:
 Adjust the parameters to create a customized uwuification process:
 ```python
-from uwuipy import uwuipy
+from uwuipy import Uwuipy
 
-uwu = uwuipy(None, 0.3, 0.3, 0.3, 1, False)
+uwu = Uwuipy(None, 0.3, 0.3, 0.3, 1, False, 4)
 print(uwu.uwuify(input()))
 ```
 
 This can produce output like:
 ```
-The quick brown fox jumps over the lazy dog
-The quick b-b-b-bwown (・\`ω\´・) ***screeches*** fox jumps uvw t-t-t-the OwO wazy dog
+The quick bwown (ᵘʷᵘ) ***glomps*** f-f-fox jyumps uvw the ***screeches*** w-w-w-wazy ***blushes*** dog
+The (ᵘﻌᵘ) quick bwown ***smirks smugly*** fox \>w\< ***screeches*** jyumps uvw t-t-t-the (uwu) wazy owo dog ~(˘▾˘~)
+The q-q-q-quick ***nuzzles your necky wecky*** b-b-bwown f-f-fox ( ᵘ ꒳ ᵘ ✼) j-j-jyumps (U ﹏ U) u-uvw ***whispers to self*** the owo w-w-w-wazy Uwu d-d-d-dog ***huggles tightly***
 ```
 
 #### Time-Based Seeding:
 Utilize time-based seeding for unique transformations:
 ```python
 from datetime import datetime
-from uwuipy import uwuipy
+from uwuipy import Uwuipy
 
 message = "Hello this is a message posted in 2017."
 seed = datetime(2017, 11, 28, 23, 55, 59, 342380).timestamp()
-uwu = uwuipy(seed)
-print(uwu.uwuify(message))
+uwu = Uwuipy(seed)
+print(uwu.uwuify(message))  # Hewwo ***blushes*** t-t-t-this is a ***cries*** message posted ***screeches*** in 2017.
 ```
 This method only uses the `uwuify()` function, accepting a string and returning an uwuified string based on the constructor parameters.
 
@@ -73,7 +75,7 @@ python3 -m uwuipy The quick brown fox jumps over the lazy dog
 ```
 Output:
 ```bash
-The quick b-b-b-bwown (・\`ω\´・) ***screeches*** fox jumps uvw t-t-t-the OwO wazy dog
+The q-q-quick bwown fox jyumps uvw the wazy dog
 ```
 
 #### REPL
@@ -81,7 +83,7 @@ REPL Mode:
 ```bash
 python3 -m uwuipy 
 >>> The quick brown fox jumps over the lazy dog
-The quick b-b-b-bwown (・\`ω\´・) ***screeches*** fox jumps uvw t-t-t-the OwO wazy dog
+The quick bwown fox jyumps uvw the wazy dog
 ```
 
 #### Help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uwuipy"
-version = "0.1.8"
+version = "0.1.9"
 description = "Allows the easy implementation of uwuifying words for applications like Discord bots and websites"
 authors = ["Cuprum77", "diminDDL", "R2Boyo25", "ThatRedKite", "pin-lee", "BadlyWrittenStylesheet"]
 license = "MIT"
@@ -13,6 +13,13 @@ python = "^3.10"
 [tool.poetry.urls]
 homepage = "https://github.com/Cuprum77/uwuipy"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2.2"
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_uwuification.py
+++ b/tests/test_uwuification.py
@@ -1,0 +1,66 @@
+import pytest
+from uwuipy import Uwuipy
+
+
+def test_uwuification_level_1():
+    # Random assortment of Monty Python quotes.
+    assert (
+        Uwuipy(1, 0, 0, 0, 0, power=1).uwuify(
+            "We want a shrubbery!! …Are you suggesting that coconuts migrate? "
+            "Shut up! Will you shut up?! Ah, now we see the violence inherent in the system!"
+        )
+        == "We want a shwubbewy!! …Awe you suggesting that coconuts migwate? "
+        "Shut up! Wiww you shut up?! Ah, now we see the viowence inhewent in the system!"
+    )
+
+
+def test_uwuification_level_2():
+    # Monty Python reference combined with a Jojo reference (Kaz: I don't watch Jojo).
+    assert (
+        Uwuipy(1, 0, 0, 0, 0, power=2).uwuify("Jojo says no to the Knights of Ni!")
+        == "Jyojyo says nyo to the Knyights of Nyi!"
+    )
+
+
+def test_uwuification_level_3():
+    assert (
+        Uwuipy(1, 0, 0, 0, 0, power=3).uwuify("Avali love to smell the roses!")
+        == "Awawi wuv to smeww the woses!"
+    )
+
+
+def test_uwuification_level_4():
+    assert (
+        Uwuipy(1, 0, 0, 0, 0, power=4).uwuify(
+            "Avali love to smell the roses! Oh! Don't put them on there! They'll melt! Don't give them an apple, either."
+        )
+        == "Awawi wuv to smeww the wowses! Owh! Down't put them own thewe! They'ww mewt! Down't giwe them awn appwe, eithew."
+    )
+
+
+def test_stuttering():
+    assert (
+        Uwuipy(1, 1, 0, 0, 0).uwuify("Hello world! (this is in parenthesis)")
+        == "H-Hewwo w-w-w-wowwd! (this i-i-is i-i-in p-pawenthesis)"
+    )
+
+
+def test_url():
+    assert (
+        Uwuipy(1, 1, 0, 0, 0).uwuify("https://example.com mailto:example@example.com")
+        == "https://example.com mailto:example@example.com"
+    )
+
+
+def test_guards():
+    with pytest.raises(ValueError):
+        Uwuipy(stutter_chance=-1)
+
+    with pytest.raises(ValueError):
+        Uwuipy(stutter_chance=2)
+
+    with pytest.raises(ValueError):
+        Uwuipy(power=0)
+
+    with pytest.raises(ValueError):
+        Uwuipy(power=5)

--- a/uwuipy/__init__.py
+++ b/uwuipy/__init__.py
@@ -1,1 +1,1 @@
-from .uwuipy import uwuipy
+from .uwuipy import Uwuipy as Uwuipy, Uwuipy

--- a/uwuipy/__main__.py
+++ b/uwuipy/__main__.py
@@ -1,4 +1,4 @@
-from uwuipy import uwuipy
+from uwuipy import Uwuipy
 from os import getenv
 import argparse
 
@@ -61,19 +61,28 @@ def main():
         "--nsfwactions",
         default=False,
         action="store_true",
-        help="Enable NFSW actions. [default: False]"
+        help="Enable NFSW actions. [default: False]",
+    )
+
+    parser.add_argument(
+        "-p",
+        "--power",
+        default=3,
+        type=int,
+        help="The uwuification strength. [default: 3 — max is 4]",
     )
 
     parser.add_argument("message", nargs=argparse.REMAINDER, help="The text to uwuify")
     args = parser.parse_args()
 
-    uwu = uwuipy(
+    uwu = Uwuipy(
         args.seed,
         args.stutterchance,
         args.facechance,
         args.actionchance,
         args.exclamationchance,
-        args.nsfwactions
+        args.nsfwactions,
+        args.power,
     )
 
     if len(args.message):


### PR DESCRIPTION
feat: add uwuification levels
feat: separate exclamations based on original use
refactor: simplify chance guards
fix: skip URIs and URNs, not just http[s] URIs
tests: add tests for uwuification levels, URIs/URNs, and the value guards

Neofetch action removed by request of Pin.

No breaking API changes were made. According to SemVer, I should've bumped it to v0.2.0 but I didn't want to break the pattern Cuprum was following.