### PR TITLE
 Add `AUTHORS` and update copyright year

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,11 @@
+# This is the list of Uwuipy's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code.
+# To see the full list of contributors, see the revision history in
+# source control.
+Cuprum77
+diminDDL
+Kazani (R2Boyo25)
+ThatRedKite
+pin-lee
+BadlyWrittenStylesheet

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Cuprum77
+Copyright (c) 2024 The Uwuipy Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Following [Google's guidelines](https://opensource.google/documentation/reference/releasing/authors/).

The copyright year was also 2022 and it is *not* 2022, heh.