### PR TITLE
fix: fix typo that caused the Uwuipy class to be unimportable using its old case

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uwuipy"
-version = "0.1.9"
+version = "0.1.10"
 description = "Allows the easy implementation of uwuifying words for applications like Discord bots and websites"
 authors = ["Cuprum77", "diminDDL", "R2Boyo25", "ThatRedKite", "pin-lee", "BadlyWrittenStylesheet"]
 license = "MIT"

--- a/uwuipy/__init__.py
+++ b/uwuipy/__init__.py
@@ -1,1 +1,1 @@
-from .uwuipy import Uwuipy as Uwuipy, Uwuipy
+from .uwuipy import Uwuipy as uwuipy, Uwuipy


### PR DESCRIPTION
Well, I can't believe I did that… I am sorry for that. I also cannot believe nobody noticed that until now.
Anyways, it's fixed now, the `Uwuipy` class is importable at `uwuipy` again, and I bumped the patch version to `10`.